### PR TITLE
Refactor dashboard layout with sidebar navigation

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,35 +1,36 @@
 <template>
   <div class="dashboard" v-if="user">
-    <header class="dashboard__header">
-      <p class="dashboard__eyebrow">Panel clínico</p>
-      <h1>Hola, {{ primerNombre }}</h1>
-      <p class="dashboard__subtitle">
-        Nos alegra verte de nuevo. Selecciona uno de los menús principales para continuar con tus tareas del día.
-      </p>
-      <p class="dashboard__meta">Miembro desde {{ fechaCreacion }}</p>
-    </header>
+    <aside class="dashboard__sidebar">
+      <div class="sidebar__header">
+        <p class="sidebar__eyebrow">Panel clínico</p>
+        <h2>Gestión integral</h2>
+      </div>
 
-    <section class="dashboard__menus">
-      <article class="menu-card" v-for="menu in mainMenus" :key="menu.title">
-        <div class="menu-card__header">
-          <h2>{{ menu.title }}</h2>
-          <p>{{ menu.description }}</p>
-        </div>
-        <ul class="menu-card__actions">
-          <li v-for="action in menu.actions" :key="action.label">
-            <button type="button" class="menu-card__action">
-              <span class="menu-card__action-title">{{ action.label }}</span>
-              <span class="menu-card__action-hint">{{ action.hint }}</span>
+      <nav class="sidebar__nav" aria-label="Secciones principales">
+        <ul>
+          <li v-for="option in menuOptions" :key="option.label">
+            <button type="button" class="sidebar__nav-item">
+              <span class="sidebar__nav-title">{{ option.label }}</span>
+              <span class="sidebar__nav-description">{{ option.description }}</span>
             </button>
           </li>
         </ul>
-      </article>
-    </section>
+      </nav>
 
-    <footer class="dashboard__footer">
-      <RouterLink class="button ghost" :to="{ name: 'home' }">Ir al sitio</RouterLink>
-      <button class="button danger" type="button" @click="handleLogout">Cerrar sesión</button>
-    </footer>
+      <footer class="sidebar__footer">
+        <RouterLink class="sidebar__link" :to="{ name: 'home' }">Ir al sitio público</RouterLink>
+        <button class="sidebar__logout" type="button" @click="handleLogout">Cerrar sesión</button>
+      </footer>
+    </aside>
+
+    <section class="dashboard__main" aria-labelledby="bienvenida">
+      <header class="welcome" id="bienvenida">
+        <p class="welcome__eyebrow">Bienvenido de nuevo</p>
+        <h1 class="welcome__title">Hola, {{ primerNombre }}</h1>
+        <p class="welcome__description">Nos alegra tenerte de regreso en Clínica del Rey.</p>
+        <p class="welcome__meta">Miembro desde {{ fechaCreacion }}</p>
+      </header>
+    </section>
   </div>
 
   <div v-else class="empty-state">
@@ -44,48 +45,30 @@ import { computed } from 'vue';
 import { RouterLink, useRouter } from 'vue-router';
 import { useAuthStore } from '@/stores/auth';
 
-type MenuAction = {
+type MenuOption = {
   label: string;
-  hint: string;
-};
-
-type MainMenu = {
-  title: string;
   description: string;
-  actions: MenuAction[];
 };
 
 const router = useRouter();
 const { user, clearUser } = useAuthStore();
 
-const mainMenus: MainMenu[] = [
+const menuOptions: MenuOption[] = [
   {
-    title: 'Gestión clínica',
-    description: 'Centraliza las consultas, pacientes y seguimiento médico en un solo lugar.',
-    actions: [
-      {
-        label: 'Consultas',
-        hint: 'Programa, revisa y da seguimiento a las citas.'
-      },
-      {
-        label: 'Pacientes',
-        hint: 'Actualiza expedientes y mantén la información de tus pacientes al día.'
-      }
-    ]
+    label: 'Crear consultas',
+    description: 'Selecciona médico y paciente, captura la información y guarda la consulta.'
   },
   {
-    title: 'Administración',
-    description: 'Administra tu equipo y controla el acceso al sistema de la clínica.',
-    actions: [
-      {
-        label: 'Médicos',
-        hint: 'Gestiona el personal médico y sus especialidades.'
-      },
-      {
-        label: 'Usuarios del sistema',
-        hint: 'Define roles y permisos para cada miembro del equipo.'
-      }
-    ]
+    label: 'Historial de consultas',
+    description: 'Revisa las consultas filtrando por médico, paciente o rangos de fechas.'
+  },
+  {
+    label: 'Gestión de médicos',
+    description: 'Crea, edita y activa o desactiva a los médicos de la clínica.'
+  },
+  {
+    label: 'Gestión de usuarios',
+    description: 'Administra usuarios del sistema y resguarda contraseñas en formato hash.'
   }
 ];
 
@@ -115,20 +98,37 @@ const handleLogout = async () => {
 <style scoped>
 .dashboard {
   display: grid;
-  gap: 2rem;
-  padding: clamp(2rem, 5vw, 3rem);
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
   background: var(--surface-raised);
   border-radius: 28px;
   box-shadow: var(--shadow-xl);
 }
 
-.dashboard__header {
-  display: grid;
-  gap: 0.75rem;
+@media (min-width: 960px) {
+  .dashboard {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    min-height: clamp(460px, 72vh, 640px);
+  }
 }
 
-.dashboard__eyebrow {
+.dashboard__sidebar {
+  display: grid;
+  gap: 2rem;
+  background: var(--surface-base);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-lg);
+}
+
+.sidebar__header h2 {
   margin: 0;
+  font-size: 1.5rem;
+}
+
+.sidebar__eyebrow {
+  margin: 0 0 0.25rem;
   font-size: 0.85rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -136,64 +136,15 @@ const handleLogout = async () => {
   color: var(--text-muted);
 }
 
-.dashboard__header h1 {
-  margin: 0;
-  font-size: clamp(2rem, 6vw, 2.6rem);
-  font-weight: 700;
-}
-
-.dashboard__subtitle {
-  margin: 0;
-  color: var(--text-muted);
-  max-width: 52ch;
-}
-
-.dashboard__meta {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--text-muted);
-}
-
-.dashboard__menus {
-  display: grid;
-  gap: 1.5rem;
-}
-
-@media (min-width: 900px) {
-  .dashboard__menus {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.menu-card {
-  background: var(--surface-base);
-  border-radius: 24px;
-  padding: clamp(1.5rem, 4vw, 2rem);
-  border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-md);
-  display: grid;
-  gap: 1.5rem;
-}
-
-.menu-card__header h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.5rem;
-}
-
-.menu-card__header p {
-  margin: 0;
-  color: var(--text-muted);
-}
-
-.menu-card__actions {
+.sidebar__nav ul {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
   display: grid;
   gap: 0.75rem;
 }
 
-.menu-card__action {
+.sidebar__nav-item {
   width: 100%;
   text-align: left;
   background: var(--surface-raised);
@@ -206,64 +157,100 @@ const handleLogout = async () => {
   cursor: pointer;
 }
 
-.menu-card__action:hover {
+.sidebar__nav-item:hover {
   border-color: var(--brand-primary);
   box-shadow: var(--shadow-lg);
   transform: translateY(-2px);
 }
 
-.menu-card__action-title {
+.sidebar__nav-title {
   font-weight: 600;
   font-size: 1.05rem;
 }
 
-.menu-card__action-hint {
+.sidebar__nav-description {
   color: var(--text-muted);
   font-size: 0.95rem;
 }
 
-.dashboard__footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+.sidebar__footer {
+  display: grid;
+  gap: 0.75rem;
 }
 
-.button {
+.sidebar__link {
+  color: var(--brand-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.sidebar__link:hover {
+  text-decoration: underline;
+}
+
+.sidebar__logout {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.85rem 1.5rem;
+  padding: 0.85rem 1.25rem;
   border-radius: 999px;
   font-weight: 600;
-  border: 1px solid transparent;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.button.ghost {
-  border-color: var(--border-strong);
-  color: var(--text-primary);
-}
-
-.button.ghost:hover {
-  border-color: var(--brand-primary);
-  color: var(--brand-primary);
-}
-
-.button.danger {
   background: linear-gradient(135deg, #ef4444, #dc2626);
   color: #fff;
+  border: none;
+  cursor: pointer;
   box-shadow: var(--shadow-lg);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.button.primary {
-  background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
-  color: #fff;
-  box-shadow: var(--shadow-lg);
-}
-
-.button:hover {
+.sidebar__logout:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-xl);
+}
+
+.dashboard__main {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-base);
+  border-radius: 24px;
+  padding: clamp(2rem, 6vw, 3.5rem);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-lg);
+}
+
+.welcome {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+  max-width: 32rem;
+}
+
+.welcome__eyebrow {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.welcome__title {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 2.8rem);
+  font-weight: 700;
+}
+
+.welcome__description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.welcome__meta {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
 }
 
 .empty-state {
@@ -283,5 +270,25 @@ const handleLogout = async () => {
 .empty-state p {
   margin: 0;
   color: var(--text-muted);
+}
+
+.button.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  box-shadow: var(--shadow-lg);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-xl);
 }
 </style>


### PR DESCRIPTION
## Summary
- add a dedicated sidebar menu to the dashboard that lists the principales opciones de gestión
- simplify the contenido principal del dashboard to mostrar solo el saludo personalizado y metadatos del usuario
- actualizar los estilos del panel para soportar el nuevo layout de dos columnas y la vista vacía

## Testing
- npm run build *(fails: vue-tsc throws "Search string not found: \"/supportedTSExtensions = .*(?=;)\"" during type check)*

------
https://chatgpt.com/codex/tasks/task_e_68df05e3e9ec8329840abb51e1a401d6