### PR TITLE
Improve patient admin styling and add login logo

### DIFF
--- a/frontend/public/logo-d.svg
+++ b/frontend/public/logo-d.svg
@@ -1,0 +1,7 @@
+<svg width="256" height="256" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Logotipo letra D</title>
+  <desc id="desc">Letra D estilizada en azul con un acento amarillo dorado.</desc>
+  <path fill="#0B5DAA" d="M96 64h168c128 0 224 82.9 224 192S392 448 264 448H96z"/>
+  <path fill="#F1F5F9" d="M200 168h88c72 0 128 34.5 128 88s-56 88-128 88h-88z" opacity="0.88"/>
+  <path fill="#E9B022" d="M200 344h86c58 0 110-28 138-74-12.2 99.5-94.6 170-200 170h-24z"/>
+</svg>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="login">
     <section class="login-card">
-      <header>
+      <header class="login-card__header">
+        <img class="login-card__logo" src="/logo-d.svg" alt="Logotipo de Clínica del Rey" />
         <p class="eyebrow">Acceso seguro</p>
         <h1>Inicia sesión en Clínica del Rey</h1>
         <p class="subtitle">
@@ -132,6 +133,18 @@ const handleSubmit = async () => {
   box-shadow: var(--shadow-xl);
   display: grid;
   gap: 1.75rem;
+}
+
+.login-card__header {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: start;
+}
+
+.login-card__logo {
+  width: clamp(72px, 12vw, 96px);
+  height: auto;
+  filter: drop-shadow(0 12px 28px rgba(37, 99, 235, 0.35));
 }
 
 .eyebrow {

--- a/frontend/src/views/PacientesAdminView.vue
+++ b/frontend/src/views/PacientesAdminView.vue
@@ -71,12 +71,13 @@
 
         <div v-if="loading" class="placeholder">Cargando pacientes...</div>
 
-        <table v-else class="table">
-          <thead>
-            <tr>
-              <th scope="col">Nombre</th>
-              <th scope="col">Teléfono</th>
-              <th scope="col">Estado</th>
+        <div v-else class="table-wrapper">
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Nombre</th>
+                <th scope="col">Teléfono</th>
+                <th scope="col">Estado</th>
               <th scope="col">Acciones</th>
             </tr>
           </thead>
@@ -102,7 +103,8 @@
               </td>
             </tr>
           </tbody>
-        </table>
+          </table>
+        </div>
       </div>
     </div>
   </section>
@@ -304,46 +306,57 @@ onMounted(() => {
 
 .form__grid {
   display: grid;
-  gap: 1rem;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   border: none;
   margin: 0;
   padding: 0;
 }
 
-@media (min-width: 640px) {
-  .form__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .field--wide {
-    grid-column: span 2;
-  }
+.field--wide {
+  grid-column: 1 / -1;
 }
 
 .field {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .field span {
   font-weight: 600;
+  color: var(--text-muted);
+  font-size: 0.95rem;
 }
 
 input[type='text'],
 input[type='tel'] {
-  border-radius: 16px;
-  border: 1px solid var(--border-subtle);
-  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  border: 1px solid var(--border-strong);
+  padding: 0.95rem 1.1rem;
   font-size: 1rem;
-  background: var(--surface-subtle);
+  background: var(--surface-glass);
   color: var(--text-primary);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(14px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+input::placeholder {
+  color: var(--text-muted);
+  opacity: 0.9;
 }
 
 input:focus {
   outline: none;
   border-color: var(--brand-primary);
   box-shadow: 0 0 0 4px var(--focus-ring);
+  transform: translateY(-2px);
+}
+
+:global(:root[data-theme='dark']) input[type='text'],
+:global(:root[data-theme='dark']) input[type='tel'] {
+  background: rgba(15, 23, 42, 0.75);
+  box-shadow: 0 18px 40px rgba(7, 37, 64, 0.45);
 }
 
 .form__actions {
@@ -420,17 +433,57 @@ input:focus {
   color: var(--text-muted);
 }
 
+
+.table-wrapper {
+  border-radius: 22px;
+  background: var(--surface-glass);
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+}
+
 .table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 0.95rem;
 }
 
-.table th,
-.table td {
-  padding: 0.85rem 1rem;
-  text-align: left;
+.table thead th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.95rem 1.1rem;
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.table tbody td {
+  padding: 1rem 1.1rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.table tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+:global(:root[data-theme='dark']) .table thead th {
+  background: rgba(37, 99, 235, 0.24);
+  color: #e2e8f0;
+}
+
+:global(:root[data-theme='dark']) .table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+:global(:root[data-theme='dark']) .table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.3);
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- refresh the patient administration form inputs and spacing for better readability across screen sizes
- wrap the patients table with a styled container, add header/row accents, and tune dark theme colors
- add the institutional D logo to the login screen via a new SVG asset

## Testing
- npm run build *(fails: vue-tsc Search string not found: "/supportedTSExtensions = .*(?=;)/")*

------
https://chatgpt.com/codex/tasks/task_e_68df1a20f8b48329b209e9246f6efd23